### PR TITLE
fix: Corrections to Typographical Errors in Documentation

### DIFF
--- a/community/solayer-valley-episodes/unstaking-credit-deduction.md
+++ b/community/solayer-valley-episodes/unstaking-credit-deduction.md
@@ -4,7 +4,7 @@ The credit deduction mechanism is designed to manage the rewards earned through 
 
 ## Accounting Deduction
 
-When you stake SOL (or any other LST on Solayer) in a pool, you earn accrue credits based on the amount and type (bSOL, jitoSOL, INF, mSOL, etc.) of SOL staked. However, if you withdraw your staked SOL before the final epoch, a portion of that will deducted. This mechanism ensures that long-term stakers are rewarded more than those who withdraw early.
+When you stake SOL (or any other LST on Solayer) in a pool, you earn accrue credits based on the amount and type (bSOL, jitoSOL, INF, mSOL, etc.) of SOL staked. However, if you withdraw your staked SOL before the final epoch, a portion of that will be deducted. This mechanism ensures that long-term stakers are rewarded more than those who withdraw early.
 
 ### Calculation
 
@@ -38,7 +38,7 @@ So, if you generated 1000 credits on the 10 SOL deposited, 50 credits will be de
 * **Credits Earned:** 300 credits (assuming a mix of native SOL and LSTs, with appropriate multipliers)
 * **Deduction: (10 / 50 \* 300) \* 0.5 = 30 credits**
 
-In this case, if you generated 300 creditson the 10 SOL deposited, 30 credits will be deducted, leaving you with 270 credits.
+In this case, if you generated 300 credits on the 10 SOL deposited, 30 credits will be deducted, leaving you with 270 credits.
 
 ### _**Example 3: Withdrawing 50% of Staked SOL**_
 

--- a/developers-guides/security/multisig-committee.md
+++ b/developers-guides/security/multisig-committee.md
@@ -1,4 +1,4 @@
-# Multisigature Committees
+# Multisignature Committees
 
 The Solayer contract is inherently upgradable for several reasons. Firstly, stage 1 will be released in multiple phases, necessitating contract upgrades. Secondly, in emergencies, the core team must be able to swiftly implement proactive changes. Lastly, to ensure transparency and a community-first approach, the Solayer core team has decided to decentralize the development process. Hence, contract ownership is migrated to a multisig of known individuals within the Solana community.
 

--- a/docs/Overview/additional-features.md
+++ b/docs/Overview/additional-features.md
@@ -11,7 +11,7 @@ Liquid staking services are a wildly popular way for users who would like to sta
 
 ### Delegated AVS operation
 
-Running software to validate a variety of AVS protocols is a task that is best left for sophisticated users who are capable of running the software efficiently and reducing the risk of service distruption. Users simply looking to receive rewards for committing their assets to be restaked may not be sufficiently sophisticated operators of AVS software to operate it safely. Or, users might simply prefer to avoid the inconvenience of running AVS software themselves.
+Running software to validate a variety of AVS protocols is a task that is best left for sophisticated users who are capable of running the software efficiently and reducing the risk of service disruption. Users simply looking to receive rewards for committing their assets to be restaked may not be sufficiently sophisticated operators of AVS software to operate it safely. Or, users might simply prefer to avoid the inconvenience of running AVS software themselves.
 
 In any case, it is possible for users restaking their assets to delegate the operation of AVS software to a sophisticated entity willing to operate the AVS software on their behalf.
 

--- a/docs/Overview/basics.md
+++ b/docs/Overview/basics.md
@@ -20,7 +20,7 @@ On decentralized blockchain networks secured by proof-of-stake, such as Ethereum
 
 On some of these proof-of-stake networks, validators can use an application-layer *restaking* system to opt-in to validate activity against additional sets of rules that define additional protocols. These protocols can provide validators with more rewards than they would otherwise earn by solely validating for the network's base protocol. If validators break the additional rules they agreed to, other participants in the restaking system can destroy their restaked assets.
 
-Constructing an AVS as a protocol secured by a restaking system sidesteps many of the hurdles it might face, as outlined in the previous section. This reduces the barriers to entry for new AVSs, creating the conditions for exiciting innovation to happen.
+Constructing an AVS as a protocol secured by a restaking system sidesteps many of the hurdles it might face, as outlined in the previous section. This reduces the barriers to entry for new AVSs, creating the conditions for exciting innovation to happen.
 
 ### Why restake on Solana?
 


### PR DESCRIPTION
This pull request addresses and corrects typographical errors found across multiple documentation files, as follows:

1. **unstaking-credit-deduction.md**  
   - Fixed "creditson" to "credits on"
   - Added missing "be" in "will be deducted"

2. **multisig-committee.md**  
   - Corrected "Multisigature" to "Multisignature" in the title

3. **additional-features.md**  
   - Fixed "distruption" to "disruption" in the description of AVS operation

4. **basics.md**  
   - Corrected "exiciting" to "exciting" in the description of restaking benefits
